### PR TITLE
post an iron-signal on drawer open and close

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,34 @@ You can can attach listeners by using one of the methods below:
 1. Polymer Event listener
 2. on- annotated event listener
 3. addEventListener vanila Javascript method
+
+In addition, an iron-signal event is fired whenever the nav bar is expanded or collapsed.
+This allows any components anywhere in the containment hierarchy to listen for this event
+and in order to reflow its layout accordingly.  This is needed because there is no reliable events for
+div resize without a window resize event.
+
+iron-signal event data:
+{ isNavExpanded: true|false, eventDetails: 'start'|'end' }
+
+Example:
+
+```
+	<iron-signals on-iron-signal-appnav="onAppNavSignal"></iron-signals>
+```
 <br />
+	...
+<br />
+
+```
+onAppNavSignal: function(event, details) {
+    if (details.isNavExpanded && details.eventDetails == 'start') {
+        // do something
+    }
+    else if (details.isNavExpanded && details.eventDetails == 'end') {
+        // do something else
+    }
+}
+```
 <hr />
 
 ## Methods

--- a/bower.json
+++ b/bower.json
@@ -14,6 +14,7 @@
     "test"
   ],
   "dependencies": {
+    "iron-signals": "PolymerElements/iron-signals#~1.0.2",
     "polymer": "~v1.1.3",
     "px-theme": "https://github.com/PredixDev/px-theme.git#~0.3.10",
     "web-animations-js": "~2.0.0"

--- a/px-app-nav.html
+++ b/px-app-nav.html
@@ -5,6 +5,7 @@
     See https://github.com/jreichenberg/grunt-dep-serve#why-do-we-need-this
 -->
 <link rel="import" href="../polymer/polymer.html"/>
+<link rel="import" href="../iron-signals/iron-signals.html"/>
 <script src="../web-animations-js/web-animations-next.min.js"></script>
 
 <!--
@@ -427,7 +428,11 @@ Nav bar / drawer for applications
      */
     navExpanderButton: function(evt){
       this.navExpanded = !this.navExpanded;
+
+      // signal name must be all lower case - didn't work otherwise.
+      this.fire('iron-signal', { name: 'appnav', data: {isNavExpanded: this.navExpanded, eventDetails: 'start'}  });
       this.ani = document.timeline.play(this._buttonAnimation(this, Polymer.dom(this.root).querySelectorAll("span")));
+      this.fire('iron-signal', { name: 'appnav', data: {isNavExpanded: this.navExpanded, eventDetails: 'end'}  });
     }
   });
 </script>


### PR DESCRIPTION
Post an iron-signal event whenever the nav bar is expanded or collapsed.  This allows any components anywhere in the containment hierarchy to listen for this event and in order to reflow its layout accordingly.   This is needed because there is no reliable events for div resize without a window resize event.
