### PR TITLE
Import dependent styles.

### DIFF
--- a/px-app-nav.html
+++ b/px-app-nav.html
@@ -8,6 +8,8 @@
 <link rel="import" href="../px-tooltip/px-tooltip.html">
 <!-- <link rel="import" href="../px-iconography-design/iconography-styles.html"> -->
 
+<link rel="import" href="../px-theme/px-theme-styles.html">
+
 <script src="../web-animations-js/web-animations-next.min.js"></script>
 
 <!--


### PR DESCRIPTION
Adds importing a dependent style module. Given that an element should be self-contained and not have any external dependencies, it shouldn't require the style module to have been loaded elsewhere.

This fixes a warning in the console and broken styles if the user has not imported the style module yet.